### PR TITLE
Build ABI3 wheels for all platforms

### DIFF
--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -36,7 +36,7 @@ jobs:
           CIBW_ARCHS_MACOS: "universal2"
           CIBW_ARCHS_WINDOWS: "AMD64 ARM64"
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
-          CIBW_BUILD: "cp38-*"
+          CIBW_BUILD: "cp38-* cp39-win_arm64"
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -1,14 +1,14 @@
 name: Build and upload to PyPI
 
 # Build on every branch push, tag push, and pull request change:
-on: [push, pull_request]
+# on: [push, pull_request]
 # Alternatively, to publish when a (published) GitHub Release is created, use the following:
-# on:
-#   push:
-#   pull_request:
-#   release:
-#     types:
-#       - published
+on:
+  push:
+  pull_request:
+  release:
+    types:
+      - published
 
 jobs:
   build_wheels:
@@ -33,8 +33,10 @@ jobs:
         uses: pypa/cibuildwheel@v2.11.3
         env:
           CIBW_ARCHS_LINUX: "x86_64 aarch64"
-          CIBW_ARCHS_MACOS: "all"
+          CIBW_ARCHS_MACOS: "universal2"
           CIBW_ARCHS_WINDOWS: "AMD64 ARM64"
+          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
+          CIBW_BUILD: "cp38-*"
 
       - uses: actions/upload-artifact@v3
         with:
@@ -59,9 +61,9 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     # upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    # if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     # alternatively, to publish when a GitHub Release is created, use the following rule:
-    # if: github.event_name == 'release' && github.event.action == 'published'
+    if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/ooz/ooz_bindings.cpp
+++ b/ooz/ooz_bindings.cpp
@@ -1,27 +1,46 @@
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+#include <vector>
 
 int Kraken_Decompress(const uint8_t *src, size_t src_len, uint8_t *dst,
                       size_t dst_len);
 
-namespace py = pybind11;
+static PyObject* ooz_decompress(PyObject* self, PyObject* args) {
+    char const* src_data;
+    Py_ssize_t src_len;
+    Py_ssize_t dst_len;
 
-PYBIND11_MODULE(ooz, m) {
-  m.doc() = "Bindings for ooz.";
-  m.def(
-      "decompress",
-      [](py::bytes const &src, int dst_len) -> py::bytes {
-        py::buffer_info info = py::buffer(src).request();
-        std::vector<uint8_t> dst(
-            (size_t)dst_len +
-            64); // 64 bytes of trailing space for decompressor to clobber
-        int rc = Kraken_Decompress(reinterpret_cast<uint8_t const *>(info.ptr),
-                                   static_cast<size_t>(info.size), dst.data(),
-                                   dst_len);
-        if (rc != dst_len) {
-          throw std::runtime_error("Could not decompress requested amount");
-        }
-        return py::bytes(reinterpret_cast<char const *>(dst.data()), dst_len);
-      },
-      py::arg("src"), py::arg("dst_len"));
+    if (!PyArg_ParseTuple(args, "y#n", &src_data, &src_len, &dst_len)) {
+        return nullptr;
+    }
+    std::vector<uint8_t> dst((size_t)dst_len + 64); // 64 bytes of trailing space for decompressor to clobber
+    int rc = Kraken_Decompress(reinterpret_cast<uint8_t const *>(src_data),
+                                static_cast<size_t>(src_len), dst.data(),
+                                dst_len);
+    if (rc != dst_len) {
+        PyErr_SetString(PyExc_RuntimeError, "Could not decompress requested amount");
+        return nullptr;
+    }
+    return PyBytes_FromStringAndSize(reinterpret_cast<char const*>(dst.data()), dst_len);
+}
+
+static PyMethodDef OozMethods[] = {
+    {"decompress", ooz_decompress, METH_VARARGS, "Decompress a block of data."},
+    {nullptr, nullptr, 0, nullptr},
+};
+
+static char const* ooz_doc = "Bindings for ooz.";
+
+static struct PyModuleDef oozmodule = {
+    PyModuleDef_HEAD_INIT,
+    "ooz",
+    ooz_doc,
+    -1,
+    OozMethods,
+};
+
+PyMODINIT_FUNC
+PyInit_ooz(void) {
+    return PyModule_Create(&oozmodule);
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=40.6.0", "pybind11>=2.5.0", "wheel"]
+requires = ["setuptools>=40.6.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ class bdist_wheel_abi3(bdist_wheel):
         python, abi, plat = super().get_tag()
 
         if python.startswith("cp"):
-            # on CPython, our wheels are abi3 and compatible back to 3.6
+            # on CPython, our wheels are abi3 and compatible back to 3.8
             return "cp38", "abi3", plat
 
         return python, abi, plat


### PR DESCRIPTION
ABI3 wheels with Python's Limited API allows us to build a single forward-compatible wheel per platform instead of the previous explosion of combinations.

This PR builds wheels based on Python 3.8 on all platforms but Windows ARM64 which has a minimum version of 3.9.